### PR TITLE
fix bad naming convention in CreateClassCommandValidator and its tests

### DIFF
--- a/src/eru.Application/Classes/Commands/CreateClass/CreateClassCommandValidator.cs
+++ b/src/eru.Application/Classes/Commands/CreateClass/CreateClassCommandValidator.cs
@@ -22,7 +22,7 @@ namespace eru.Application.Classes.Commands.CreateClass
 
             RuleFor(x => x.Section)
                 .NotEmpty().WithMessage("Section cannot be empty.")
-                .MaximumLength(255).WithMessage("Section must have length up to 255 characters");
+                .MaximumLength(255).WithMessage("Section must have length up to 255 characters.");
         }
 
         private async Task<bool> IsUnique(CreateClassCommand command, CancellationToken cancellationToken) 


### PR DESCRIPTION
Fixes #74 